### PR TITLE
Simplify instructions and example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # On Ubuntu 18.04, get the latest CMake from https://apt.kitware.com/.
 cmake_minimum_required(VERSION 3.18)
-set(CMAKE_CXX_STANDARD 14)
+
 project(Open3DCMakeExternalProject LANGUAGES C CXX)
 
 option(GLIBCXX_USE_CXX11_ABI   "Set -D_GLIBCXX_USE_CXX11_ABI=1"       OFF)
@@ -35,13 +35,18 @@ ExternalProject_Add(
         -DBUILD_PYTHON_MODULE=OFF
         -DBUILD_EXAMPLES=OFF
 )
-ExternalProject_Get_Property(external_open3d INSTALL_DIR)
-set(OPEN3D_INCLUDE_DIRS ${INSTALL_DIR}/include ${INSTALL_DIR}/include/open3d/3rdparty)
-set(OPEN3D_LIB_DIR ${INSTALL_DIR}/lib)
 
-add_executable(Draw Draw.cpp)
-add_dependencies(Draw external_open3d)
-target_include_directories(Draw PRIVATE ${OPEN3D_INCLUDE_DIRS})
-target_link_directories(Draw PRIVATE ${OPEN3D_LIB_DIR})
-target_link_libraries(Draw PRIVATE Open3D)
-target_compile_definitions(Draw PRIVATE _GLIBCXX_USE_CXX11_ABI=$<BOOL:${GLIBCXX_USE_CXX11_ABI}>)
+# Simulate importing Open3D::Open3D
+ExternalProject_Get_Property(external_open3d INSTALL_DIR)
+add_library(Open3DHelper INTERFACE)
+add_dependencies(Open3DHelper external_open3d)
+target_compile_features(Open3DHelper INTERFACE cxx_std_14)
+target_compile_definitions(Open3DHelper INTERFACE _GLIBCXX_USE_CXX11_ABI=$<BOOL:${GLIBCXX_USE_CXX11_ABI}>)
+target_include_directories(Open3DHelper INTERFACE "${INSTALL_DIR}/include" "${INSTALL_DIR}/include/open3d/3rdparty")
+target_link_directories(Open3DHelper INTERFACE "${INSTALL_DIR}/lib")
+target_link_libraries(Open3DHelper INTERFACE Open3D)
+add_library(Open3D::Open3D ALIAS Open3DHelper)
+
+add_executable(Draw)
+target_sources(Draw PRIVATE Draw.cpp)
+target_link_libraries(Draw PRIVATE Open3D::Open3D)

--- a/Draw.cpp
+++ b/Draw.cpp
@@ -29,19 +29,17 @@
 #include "open3d/Open3D.h"
 
 int main(int argc, char *argv[]) {
-    using namespace open3d;
-
     if (argc == 2) {
         std::string option(argv[1]);
         if (option == "--skip-for-unit-test") {
-            utility::LogInfo("Skiped for unit test.");
+            open3d::utility::LogInfo("Skiped for unit test.");
             return 0;
         }
     }
 
-    auto sphere = geometry::TriangleMesh::CreateSphere(1.0);
+    auto sphere = open3d::geometry::TriangleMesh::CreateSphere(1.0);
     sphere->ComputeVertexNormals();
     sphere->PaintUniformColor({0.0, 1.0, 0.0});
-    visualization::DrawGeometries({sphere});
+    open3d::visualization::DrawGeometries({sphere});
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -9,24 +9,27 @@ project:
 For more details, check out the [Open3D repo](https://github.com/intel-isl/Open3D) and
 [Open3D docs](http://www.open3d.org/docs/release/cpp_project.html).
 
-## Ubuntu 18.04+
+## Step 1: Install Open3D dependencies
+
+On Ubuntu:
 
 ```bash
 # Install minimal Open3D compilation dependencies. For the full list, checkout:
 # https://github.com/intel-isl/Open3D/blob/master/util/install_deps_ubuntu.sh
 sudo apt-get --yes install xorg-dev libglu1-mesa-dev
-
-# Compile your example project with Open3D.
-git clone https://github.com/intel-isl/open3d-cmake-external-project.git
-cd open3d-cmake-external-project
-mkdir build
-cd build
-cmake ..
-make -j$(nproc)
-./Draw
 ```
 
-## macOS
+On macOS/Windows:
+
+```bash
+# Skip this step
+```
+
+## Step 2: Use Open3D in this example project
+
+You can specify the number of parallel jobs to speed up compilation.
+
+On Ubuntu/macOS:
 
 ```bash
 git clone https://github.com/intel-isl/open3d-cmake-external-project.git
@@ -34,18 +37,18 @@ cd open3d-cmake-external-project
 mkdir build
 cd build
 cmake ..
-make -j$(nproc)
+cmake --build . --config Release --parallel 12
 ./Draw
 ```
 
-## Windows 10
+On Windows:
 
 ```batch
 git clone https://github.com/intel-isl/open3d-cmake-external-project.git
 cd open3d-cmake-external-project
 mkdir build
 cd build
-cmake -G "Visual Studio 16 2019 Win64" -A x64 ..
-cmake --build . --config Release
+cmake ..
+cmake --build . --config Release --parallel 12
 Release\Draw
 ```


### PR DESCRIPTION
- Remove explicit setting of  `CMAKE_CXX_STANDARD` as this is will be handled by the `Open3D::Open3D` target
- Simulate importing the `Open3D::Open3D` target to have a reusable and unique way to link against it
- Use `target_sources` and always specify the scope (e.g. `PRIVATE`) to encourage modern CMake
- Link against the `Open3D::Open3D` target
- Remove `using namespace open3d` to discourage this bad practice
- Split installation of dependencies to a separate step and change the formatting to be consistent with the `open3d-cmake-find-package` repository
- Use CMake's cross-platform build command along with `--parallel` to show multi-threaded builds
- Remove `-G "Visual Studio 16 2019 Win64" -A x64` as this is already the default configuration for Visual Studio 2019